### PR TITLE
VTube Stage に視覚効果とカメラ追従改善を追加

### DIFF
--- a/packages/vtube-stage/public/avatars.json
+++ b/packages/vtube-stage/public/avatars.json
@@ -1,6 +1,8 @@
 [
   {
     "id": "avatar1",
+    "name": "ずんだもん",
+    "voiceVoxSpeaker": "ずんだもん",
     "vrmUrl": "/avatar/avatar.vrm",
     "animationUrls": {
       "idle": "/vrma/idle_pose.vrma",
@@ -15,10 +17,22 @@
     "headYaw": 0,
     "currentAnimationName": "idle",
     "position": [-0.5, 0, 0],
-    "height": 1.45
+    "height": 1.45,
+    "lookAtConfig": {
+      "yawLimitDeg": 50,
+      "pitchLimitDeg": 30,
+      "headWeight": 0.5,
+      "neckWeight": 0.5
+    },
+    "blinkConfig": {
+      "disabledEmotions": ["happy"]
+    },
+    "autoReturnToIdleTimeout": 3000
   },
   {
     "id": "avatar2",
+    "name": "四国めたん",
+    "voiceVoxSpeaker": "四国めたん",
     "vrmUrl": "/avatar/avatar2.vrm",
     "animationUrls": {
       "idle": "/vrma/idle_pose.vrma",
@@ -33,6 +47,16 @@
     "headYaw": 0,
     "currentAnimationName": "idle",
     "position": [0.5, 0, 0],
-    "height": 1.65
+    "height": 1.65,
+    "lookAtConfig": {
+      "yawLimitDeg": 50,
+      "pitchLimitDeg": 30,
+      "headWeight": 0.5,
+      "neckWeight": 0.5
+    },
+    "blinkConfig": {
+      "disabledEmotions": ["happy"]
+    },
+    "autoReturnToIdleTimeout": 3000
   }
 ]

--- a/packages/vtube-stage/public/avatars.json
+++ b/packages/vtube-stage/public/avatars.json
@@ -22,7 +22,8 @@
       "yawLimitDeg": 50,
       "pitchLimitDeg": 30,
       "headWeight": 0.5,
-      "neckWeight": 0.5
+      "neckWeight": 0.5,
+      "disableLookAtAnimations": ["agree", "no"]
     },
     "blinkConfig": {
       "disabledEmotions": ["happy"]
@@ -52,7 +53,8 @@
       "yawLimitDeg": 50,
       "pitchLimitDeg": 30,
       "headWeight": 0.5,
-      "neckWeight": 0.5
+      "neckWeight": 0.5,
+      "disableLookAtAnimations": ["agree", "no"]
     },
     "blinkConfig": {
       "disabledEmotions": ["happy"]

--- a/packages/vtube-stage/public/visual_effects.json
+++ b/packages/vtube-stage/public/visual_effects.json
@@ -1,0 +1,39 @@
+{
+  "bloom": {
+    "enabled": true,
+    "luminanceThreshold": 1.2,
+    "mipmapBlur": true,
+    "intensity": 0.4,
+    "radius": 0.6
+  },
+  "vignette": {
+    "enabled": true,
+    "eskil": false,
+    "offset": 0.2,
+    "darkness": 0.7
+  },
+  "chromaticAberration": {
+    "enabled": true,
+    "offset": [0.002, 0.002],
+    "radialModulation": true,
+    "modulationOffset": 0.6
+  },
+  "glitch": {
+    "enabled": false,
+    "delay": [9, 15],
+    "duration": [0.025, 0.05],
+    "strength": [0.05, 0.1],
+    "mode": "SPORADIC",
+    "active": true,
+    "ratio": 0.85
+  },
+  "scanline": {
+    "enabled": false,
+    "density": 1.25,
+    "opacity": 0.1
+  },
+  "noise": {
+    "enabled": true,
+    "opacity": 0.05
+  }
+}

--- a/packages/vtube-stage/src/components/DebugSidebar.tsx
+++ b/packages/vtube-stage/src/components/DebugSidebar.tsx
@@ -94,14 +94,11 @@ export const DebugSidebar: React.FC<DebugSidebarProps> = ({
   // 選択中のターゲットに対応するスピーカー情報を取得（簡易マッピング）
   const currentSpeaker = React.useMemo(() => {
     if (!speechTargetId) return null;
-    // speechTargetId = 'avatar1' -> 'ずんだもん', 'avatar2' -> '四国めたん'
-    const nameMap: Record<string, string> = {
-      avatar1: 'ずんだもん',
-      avatar2: '四国めたん',
-    };
-    const targetName = nameMap[speechTargetId];
-    return VOICE_VOX_SPEAKERS.find(s => s.name === targetName);
-  }, [speechTargetId]);
+    const targetAvatar = avatars.find(a => a.id === speechTargetId);
+    if (!targetAvatar || !targetAvatar.voiceVoxSpeaker) return null;
+
+    return VOICE_VOX_SPEAKERS.find(s => s.name === targetAvatar.voiceVoxSpeaker);
+  }, [speechTargetId, avatars]);
 
   // 吹き出し表示
   const handleSpeak = () => {
@@ -127,7 +124,7 @@ export const DebugSidebar: React.FC<DebugSidebarProps> = ({
 
   // Markdownコントロール用ローカル状態
   const [markdownText, setMarkdownText] = React.useState<string>(
-    '# Hello\\n- item 1 long long long long long long long long long long long long long long long long long long long long long long text.\\n- item 2\\n## Subtitle\\n- item 1\\n- item 2\\n- item 3\\n- item 4\\n- item 5\\n- item 6\\n- item 7\\n- item 8\\n- item 9\\n- item 10\\n- item 11\\n- item 12\\n- item 13\\n- item 14\\n- item 15\\n- item 16\\n- item 17\\n- item 18\\n- item 19\\n- item 20\\n- item 21\\n- item 22\\n- item 23\\n- item 24\\n- item 25\\n- item 26\\n- item 27\\n- item 28\\n- item 29\\n- item 30'
+    '# Hello\n- item 1 long long long long long long long long long long long long long long long long long long long long long long text.\n- item 2\n## Subtitle\n- item 1\n- item 2\n- item 3\n- item 4\n- item 5\n- item 6\n- item 7\n- item 8\n- item 9\n- item 10\n- item 11\n- item 12\n- item 13\n- item 14\n- item 15\n- item 16\n- item 17\n- item 18\n- item 19\n- item 20\n- item 21\n- item 22\n- item 23\n- item 24\n- item 25\n- item 26\n- item 27\n- item 28\n- item 29\n- item 30'
   );
 
   const handleShowMarkdown = () => {
@@ -191,7 +188,7 @@ export const DebugSidebar: React.FC<DebugSidebarProps> = ({
               >
                 {avatars.map(avatar => (
                   <MenuItem key={avatar.id} value={avatar.id}>
-                    {avatar.id}
+                    {avatar.name || avatar.id}
                   </MenuItem>
                 ))}
               </Select>
@@ -226,7 +223,7 @@ export const DebugSidebar: React.FC<DebugSidebarProps> = ({
             >
               {avatars.map(avatar => (
                 <MenuItem key={avatar.id} value={avatar.id}>
-                  {avatar.id}
+                  {avatar.name || avatar.id}
                 </MenuItem>
               ))}
             </Select>

--- a/packages/vtube-stage/src/components/SceneContent.tsx
+++ b/packages/vtube-stage/src/components/SceneContent.tsx
@@ -1,8 +1,8 @@
 // src/components/SceneContent.tsx
 import React, { useRef, useEffect, useMemo, Suspense } from 'react';
 import * as THREE from 'three';
-import { OrbitControls, Sky, MeshReflectorMaterial, Float, Text3D, Cloud, Clouds } from '@react-three/drei';
-import { EffectComposer, Bloom, Vignette } from '@react-three/postprocessing';
+import { OrbitControls, Sky, MeshReflectorMaterial, Float, Text3D, Cloud, Clouds, Grid } from '@react-three/drei';
+import { EffectComposer, Bloom, Vignette, ChromaticAberration } from '@react-three/postprocessing';
 import { VRMAvatar } from './VRMAvatar';
 import { VRM } from '@pixiv/three-vrm';
 import { AvatarState } from '../types/avatar_types';
@@ -86,7 +86,7 @@ export const SceneContent: React.FC<SceneContentProps> = ({ avatars, controlsEna
 
       {/* 4. 床の改善: MeshReflectorMaterialで鏡面反射 */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]}>
-        <planeGeometry args={[10, 10]} />
+        <planeGeometry args={[13.25, 13.25]} />
         <MeshReflectorMaterial
           blur={[300, 100]}
           resolution={1024}
@@ -101,6 +101,22 @@ export const SceneContent: React.FC<SceneContentProps> = ({ avatars, controlsEna
           mirror={0.5}
         />
       </mesh>
+
+      {/* サイバー風グリッド床 */}
+      <Grid
+        position={[0, 0.01, 0]} // 床のわずかに下
+        args={[10.5, 10.5]} // グリッド全体のサイズ
+        cellSize={0.6} // 小さいマスのサイズ
+        cellThickness={1} // 小さいマスの線の太さ
+        cellColor="#6f6f6f" // 小さいマスの色
+        sectionSize={3.3} // 大きい区切りのサイズ
+        sectionThickness={1.5} // 大きい区切りの線の太さ
+        sectionColor="#9d4b4b" // 大きい区切りの色（赤や青に変えると雰囲気が激変します）
+        fadeDistance={30} // 奥の方をフェードアウトさせる距離
+        fadeStrength={1}
+        followCamera={false}
+        infiniteGrid // どこまでカメラが動いても床が続く
+      />
 
       {/* 5. 空間演出: 浮遊するテキストとオブジェクト */}
       <Float speed={2} rotationIntensity={0.5} floatIntensity={0.5}>
@@ -151,6 +167,13 @@ export const SceneContent: React.FC<SceneContentProps> = ({ avatars, controlsEna
         />
         {/* Vignette: 四隅を暗くしてシネマティックに */}
         <Vignette eskil={false} offset={0.2} darkness={0.7} />
+
+        {/* ▼▼▼ 追加: 色収差 ▼▼▼ */}
+        <ChromaticAberration
+          offset={[0.002, 0.002]} // ずらす量（0.001~0.005くらいが上品）
+          radialModulation={true}
+          modulationOffset={0.6} // 中心からどれくらい離れたら収差が出始めるか
+        />
       </EffectComposer>
       {/* Camera Controls */}
       {controlsEnabled && <OrbitControls ref={controlsRef} makeDefault />}

--- a/packages/vtube-stage/src/components/SceneContent.tsx
+++ b/packages/vtube-stage/src/components/SceneContent.tsx
@@ -2,7 +2,16 @@
 import React, { useRef, useEffect, useMemo, Suspense } from 'react';
 import * as THREE from 'three';
 import { OrbitControls, Sky, MeshReflectorMaterial, Float, Text3D, Cloud, Clouds, Grid } from '@react-three/drei';
-import { EffectComposer, Bloom, Vignette, ChromaticAberration } from '@react-three/postprocessing';
+import {
+  EffectComposer,
+  Bloom,
+  Vignette,
+  ChromaticAberration,
+  Glitch,
+  Scanline,
+  Noise,
+} from '@react-three/postprocessing';
+import { GlitchMode } from 'postprocessing';
 import { VRMAvatar } from './VRMAvatar';
 import { VRM } from '@pixiv/three-vrm';
 import { AvatarState } from '../types/avatar_types';
@@ -168,11 +177,32 @@ export const SceneContent: React.FC<SceneContentProps> = ({ avatars, controlsEna
         {/* Vignette: 四隅を暗くしてシネマティックに */}
         <Vignette eskil={false} offset={0.2} darkness={0.7} />
 
-        {/* ▼▼▼ 追加: 色収差 ▼▼▼ */}
+        {/* 色収差 */}
         <ChromaticAberration
           offset={[0.002, 0.002]} // ずらす量（0.001~0.005くらいが上品）
           radialModulation={true}
           modulationOffset={0.6} // 中心からどれくらい離れたら収差が出始めるか
+        />
+
+        {/* 時々走るデジタルノイズ */}
+        <Glitch
+          delay={new THREE.Vector2(9, 15)} // ノイズが発生しない間隔（秒）のランダム範囲
+          duration={new THREE.Vector2(0.025, 0.05)} // ノイズが続いている時間（秒）。短めがおすすめ
+          strength={new THREE.Vector2(0.05, 0.1)} // ノイズの強さ。弱めにしておくと「通信障害」っぽくてリアル
+          mode={GlitchMode.SPORADIC} // SPORADIC = 間欠的（ランダム）に発生
+          active={true}
+          ratio={0.85} // ノイズの発生確率（しきい値）
+        />
+
+        {/* モニター風の走査線 */}
+        <Scanline
+          density={1.25} // 線の密度
+          opacity={0.1} // 0.05〜0.1 くらいのごく薄い値にするのがコツ
+        />
+
+        {/* フィルム粒子のようなザラつき */}
+        <Noise
+          opacity={0.05} // こちらも0.02〜0.05くらいで「隠し味」程度に
         />
       </EffectComposer>
       {/* Camera Controls */}

--- a/packages/vtube-stage/src/components/VRMAvatar.tsx
+++ b/packages/vtube-stage/src/components/VRMAvatar.tsx
@@ -183,7 +183,15 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentAnimationName, loadedAnimationNames, id, onAnimationEnd, createAnimationClipFromVRMA]);
+  }, [
+    currentAnimationName,
+    loadedAnimationNames,
+    id,
+    onAnimationEnd,
+    createAnimationClipFromVRMA,
+    vrmUrl,
+    autoReturnToIdleTimeout,
+  ]);
 
   const { updateExpressions } = useFacialExpression(isLoaded ? vrmRef.current : null, current_emotion, isTtsSpeaking);
   const { lookAtTargetRef, updateLookAt } = useAvatarLookAt(

--- a/packages/vtube-stage/src/components/VRMAvatar.tsx
+++ b/packages/vtube-stage/src/components/VRMAvatar.tsx
@@ -26,6 +26,18 @@ export interface VRMAvatarProps {
   onTTSComplete?: (speakId: string) => void;
   onAnimationEnd?: (animationName: string) => void;
   height?: number;
+  voiceVoxSpeaker?: string;
+  name?: string;
+  lookAtConfig?: {
+    yawLimitDeg: number;
+    pitchLimitDeg: number;
+    headWeight: number;
+    neckWeight: number;
+  };
+  blinkConfig?: {
+    disabledEmotions: string[];
+  };
+  autoReturnToIdleTimeout?: number;
 }
 
 export const VRMAvatar: React.FC<VRMAvatarProps> = ({
@@ -40,6 +52,10 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
   onTTSComplete,
   onAnimationEnd,
   height,
+  voiceVoxSpeaker,
+  lookAtConfig,
+  blinkConfig,
+  autoReturnToIdleTimeout = 3000,
 }) => {
   const { gltf, vrmRef, mixer, isLoaded, loadedAnimationNames, createAnimationClipFromVRMA } = useVrmModel(
     vrmUrl,
@@ -115,7 +131,7 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
           currentAction.current = newAction;
           currentMixer.addEventListener('finished', onFinished);
 
-          // 3秒後にidleへ強制遷移
+          // 3秒後にidleへ強制遷移 (設定値を使用)
           animationTimeoutRef.current = window.setTimeout(() => {
             if (currentAction.current === newAction && currentAnimationName !== 'idle') {
               if (currentAction.current) {
@@ -131,7 +147,7 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
                   .fadeIn(ANIMATION_FADE_DURATION)
                   .play();
                 currentAction.current = idleAction;
-                console.log(`Avatar ${vrmUrl}: forcibly changed to idle after 3s`);
+                console.log(`Avatar ${vrmUrl}: forcibly changed to idle after ${autoReturnToIdleTimeout}ms`);
                 if (onAnimationEnd) {
                   onAnimationEnd(newAnimationName); // アニメーション終了を通知
                 }
@@ -140,7 +156,7 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
               currentMixer.removeEventListener('finished', onFinished);
             }
             animationTimeoutRef.current = null;
-          }, 3000);
+          }, autoReturnToIdleTimeout);
         } else {
           newAction.reset().setEffectiveTimeScale(1).setEffectiveWeight(1).fadeIn(ANIMATION_FADE_DURATION).play();
           currentAction.current = newAction;
@@ -172,9 +188,10 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
   const { lookAtTargetRef, updateLookAt } = useAvatarLookAt(
     isLoaded ? vrmRef.current : null,
     isLoaded,
-    currentAnimationName
+    currentAnimationName,
+    lookAtConfig
   );
-  const { updateBlink } = useAvatarBlink(isLoaded ? vrmRef.current : null, current_emotion);
+  const { updateBlink } = useAvatarBlink(isLoaded ? vrmRef.current : null, current_emotion, blinkConfig);
 
   // --- Frame Update ---
   useFrame((state, delta) => {
@@ -192,9 +209,9 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
   const playTTS = useCallback(
     async (text: string, onPlay?: () => void, style?: string) => {
       console.log('[TTS] playTTS called with text:', text);
-      await playVoice(id, text, onPlay, style); // onPlayを渡す
+      await playVoice(text, onPlay, style, voiceVoxSpeaker); // onPlayを渡す, speakerPass
     },
-    [id]
+    [voiceVoxSpeaker]
   );
 
   // speechTextが変化したらTTS再生→終了後に吹き出しを閉じる

--- a/packages/vtube-stage/src/components/VRMAvatar.tsx
+++ b/packages/vtube-stage/src/components/VRMAvatar.tsx
@@ -33,6 +33,7 @@ export interface VRMAvatarProps {
     pitchLimitDeg: number;
     headWeight: number;
     neckWeight: number;
+    disableLookAtAnimations?: string[];
   };
   blinkConfig?: {
     disabledEmotions: string[];

--- a/packages/vtube-stage/src/constants/avatar_config.ts
+++ b/packages/vtube-stage/src/constants/avatar_config.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_AVATAR_CONFIG = {
+  blink: {
+    disabledEmotions: ['happy', 'sleepy', 'wink'],
+  },
+  lookAt: {
+    disabledAnimations: ['agree', 'no', 'sleep'],
+  },
+};

--- a/packages/vtube-stage/src/hooks/useAvatarBlink.ts
+++ b/packages/vtube-stage/src/hooks/useAvatarBlink.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { VRM } from '@pixiv/three-vrm';
+import { DEFAULT_AVATAR_CONFIG } from '../constants/avatar_config';
 
 export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string, config?: { disabledEmotions: string[] }) => {
   const blinkTimerRef = useRef<number>(Math.random() * 2 + 1); // 瞬きタイマー
@@ -10,7 +11,7 @@ export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string, config?:
     (delta: number) => {
       if (!vrm || !vrm.expressionManager) return;
 
-      const disabledEmotions = config?.disabledEmotions ?? ['happy'];
+      const disabledEmotions = config?.disabledEmotions ?? DEFAULT_AVATAR_CONFIG.blink.disabledEmotions;
       if (disabledEmotions.includes(currentEmotion)) {
         // happyなどのときは瞬きしない（笑顔で目が細くなっているため干渉を防ぐ）
         vrm.expressionManager.setValue('blink', 0);

--- a/packages/vtube-stage/src/hooks/useAvatarBlink.ts
+++ b/packages/vtube-stage/src/hooks/useAvatarBlink.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react';
 import { VRM } from '@pixiv/three-vrm';
 
-export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string) => {
+export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string, config?: { disabledEmotions: string[] }) => {
   const blinkTimerRef = useRef<number>(Math.random() * 2 + 1); // 瞬きタイマー
   const isBlinkingRef = useRef<boolean>(false);
   const blinkProgressRef = useRef<number>(0);
@@ -10,8 +10,9 @@ export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string) => {
     (delta: number) => {
       if (!vrm || !vrm.expressionManager) return;
 
-      if (currentEmotion === 'happy') {
-        // happyのときは瞬きしない（笑顔で目が細くなっているため干渉を防ぐ）
+      const disabledEmotions = config?.disabledEmotions ?? ['happy'];
+      if (disabledEmotions.includes(currentEmotion)) {
+        // happyなどのときは瞬きしない（笑顔で目が細くなっているため干渉を防ぐ）
         vrm.expressionManager.setValue('blink', 0);
         // 次の瞬きまでの時間をリセット
         blinkTimerRef.current = Math.random() * 2 + 1;
@@ -52,7 +53,7 @@ export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string) => {
         }
       }
     },
-    [vrm, currentEmotion]
+    [vrm, currentEmotion, config]
   );
 
   return { updateBlink };

--- a/packages/vtube-stage/src/hooks/useAvatarLookAt.ts
+++ b/packages/vtube-stage/src/hooks/useAvatarLookAt.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { VRM } from '@pixiv/three-vrm';
 import { RootState } from '@react-three/fiber';
+import { DEFAULT_AVATAR_CONFIG } from '../constants/avatar_config';
 
 export const useAvatarLookAt = (
   vrm: VRM | null,
@@ -38,7 +39,7 @@ export const useAvatarLookAt = (
       const localHeadPos = vrm.scene.worldToLocal(headWorldPos);
 
       // 特定のアニメーションの最中はLookAtを無効化し、正面を見るようにする
-      const disabledAnimations = config?.disableLookAtAnimations ?? ['agree', 'no']; // Default to old hardcoded values if missing
+      const disabledAnimations = config?.disableLookAtAnimations ?? DEFAULT_AVATAR_CONFIG.lookAt.disabledAnimations;
       if (currentAnimationName && disabledAnimations.includes(currentAnimationName)) {
         // ローカル座標系で正面(Z+)にターゲットを置く
         const centerDir = new THREE.Vector3(0, 0, 1.0);

--- a/packages/vtube-stage/src/hooks/useAvatarLookAt.ts
+++ b/packages/vtube-stage/src/hooks/useAvatarLookAt.ts
@@ -7,7 +7,13 @@ export const useAvatarLookAt = (
   vrm: VRM | null,
   isLoaded: boolean,
   currentAnimationName: string | null,
-  config?: { yawLimitDeg: number; pitchLimitDeg: number; headWeight: number; neckWeight: number }
+  config?: {
+    yawLimitDeg: number;
+    pitchLimitDeg: number;
+    headWeight: number;
+    neckWeight: number;
+    disableLookAtAnimations?: string[];
+  }
 ) => {
   const lookAtTargetRef = useRef<THREE.Object3D>(new THREE.Object3D());
 
@@ -31,8 +37,9 @@ export const useAvatarLookAt = (
       headNode.getWorldPosition(headWorldPos);
       const localHeadPos = vrm.scene.worldToLocal(headWorldPos);
 
-      // 特定のアニメーション（頷く、首を振る）の最中はLookAtを無効化し、正面を見るようにする
-      if (currentAnimationName === 'agree' || currentAnimationName === 'no') {
+      // 特定のアニメーションの最中はLookAtを無効化し、正面を見るようにする
+      const disabledAnimations = config?.disableLookAtAnimations ?? ['agree', 'no']; // Default to old hardcoded values if missing
+      if (currentAnimationName && disabledAnimations.includes(currentAnimationName)) {
         // ローカル座標系で正面(Z+)にターゲットを置く
         const centerDir = new THREE.Vector3(0, 0, 1.0);
         const centerPos = new THREE.Vector3().addVectors(localHeadPos, centerDir);

--- a/packages/vtube-stage/src/pages/StagePage.tsx
+++ b/packages/vtube-stage/src/pages/StagePage.tsx
@@ -61,7 +61,7 @@ const MarkdownOverlay = styled.div<{ $isCloseUp?: boolean }>`
   padding: 8px;
   border-radius: 8px;
   max-width: ${props => (props.$isCloseUp ? '40%' : '80%')};
-  max-height: 80%;
+  max-height: 40%;
   text-align: left;
   font-size: 1.0rem;
   line-height: 1.1;

--- a/packages/vtube-stage/src/services/tts_service.ts
+++ b/packages/vtube-stage/src/services/tts_service.ts
@@ -36,18 +36,13 @@ export function splitAndMergeSentences(input: string): string[] {
 
 import { VOICE_VOX_SPEAKERS } from '../constants/voice_vox_speakers';
 
-function getSpeakerId(characterId: string, style?: string): number {
-  const charNameMap: Record<string, string> = {
-    avatar1: 'ずんだもん',
-    avatar2: '四国めたん',
-  };
-  const targetName = charNameMap[characterId];
+function getSpeakerId(voiceVoxSpeaker?: string, style?: string): number {
   // デフォルト: ずんだもん ノーマル (3)
   const DEFAULT_ID = 3;
 
-  if (!targetName) return DEFAULT_ID;
+  if (!voiceVoxSpeaker) return DEFAULT_ID;
 
-  const speaker = VOICE_VOX_SPEAKERS.find(s => s.name === targetName);
+  const speaker = VOICE_VOX_SPEAKERS.find(s => s.name === voiceVoxSpeaker);
   if (!speaker) return DEFAULT_ID;
 
   if (style) {
@@ -60,8 +55,13 @@ function getSpeakerId(characterId: string, style?: string): number {
   return normalStyle ? normalStyle.id : speaker.styles[0].id;
 }
 
-export async function playVoice(characterId: string, text: string, onPlay?: () => void, style?: string): Promise<void> {
-  const speakerId = getSpeakerId(characterId, style);
+export async function playVoice(
+  text: string,
+  onPlay?: () => void,
+  style?: string,
+  voiceVoxSpeaker?: string
+): Promise<void> {
+  const speakerId = getSpeakerId(voiceVoxSpeaker, style);
 
   const sentences = splitAndMergeSentences(text);
 

--- a/packages/vtube-stage/src/types/avatar_types.ts
+++ b/packages/vtube-stage/src/types/avatar_types.ts
@@ -25,6 +25,7 @@ export interface AvatarState {
     pitchLimitDeg: number;
     headWeight: number;
     neckWeight: number;
+    disableLookAtAnimations?: string[];
   };
   blinkConfig?: {
     disabledEmotions: string[];

--- a/packages/vtube-stage/src/types/avatar_types.ts
+++ b/packages/vtube-stage/src/types/avatar_types.ts
@@ -9,6 +9,8 @@ export interface SpeakMessage {
 // AvatarState インターフェースの定義
 export interface AvatarState {
   id: string;
+  name?: string; // Display name
+  voiceVoxSpeaker?: string; // VoiceVox matching name
   vrmUrl: string;
   animationUrls: { [key: string]: string };
   currentEmotion: string;
@@ -18,4 +20,14 @@ export interface AvatarState {
   onTTSComplete?: (speakId: string) => void;
   onAnimationEnd?: (animationName: string) => void;
   height?: number;
+  lookAtConfig?: {
+    yawLimitDeg: number;
+    pitchLimitDeg: number;
+    headWeight: number;
+    neckWeight: number;
+  };
+  blinkConfig?: {
+    disabledEmotions: string[];
+  };
+  autoReturnToIdleTimeout?: number;
 }

--- a/packages/vtube-stage/src/types/scene_types.ts
+++ b/packages/vtube-stage/src/types/scene_types.ts
@@ -23,7 +23,7 @@ export interface VisualEffectsConfig {
     delay: [number, number];
     duration: [number, number];
     strength: [number, number];
-    mode: string;
+    mode: 'SPORADIC' | 'CONSTANT_MILD';
     active: boolean;
     ratio: number;
   };

--- a/packages/vtube-stage/src/types/scene_types.ts
+++ b/packages/vtube-stage/src/types/scene_types.ts
@@ -1,3 +1,43 @@
+export interface VisualEffectsConfig {
+  bloom: {
+    enabled: boolean;
+    luminanceThreshold: number;
+    mipmapBlur: boolean;
+    intensity: number;
+    radius: number;
+  };
+  vignette: {
+    enabled: boolean;
+    eskil: boolean;
+    offset: number;
+    darkness: number;
+  };
+  chromaticAberration: {
+    enabled: boolean;
+    offset: [number, number];
+    radialModulation: boolean;
+    modulationOffset: number;
+  };
+  glitch: {
+    enabled: boolean;
+    delay: [number, number];
+    duration: [number, number];
+    strength: [number, number];
+    mode: string;
+    active: boolean;
+    ratio: number;
+  };
+  scanline: {
+    enabled: boolean;
+    density: number;
+    opacity: number;
+  };
+  noise: {
+    enabled: boolean;
+    opacity: number;
+  };
+}
+
 export interface StageState {
   currentMarkdownText: string | null;
   camera: {


### PR DESCRIPTION
## 1. コンテキスト（Why）

- **Issue へのリンク:** Fixes #N/A
- **動機/背景:**
  - VTube Stage の表現力向上と、カメラ追従の挙動改善を行うため。

## 2. 変更点（What）

- **サマリー:**
  - シーンの視覚効果設定（グリッチ、ノイズ、クロマティックアバレーション、サイバー床）を追加。
  - アバター設定のリファクタリングと、lookAt/blink 仕様を拡充。
  - アクティブキャラクターのカメラ追従対象解決を追加。

- **影響範囲:**
  - vtube-stage の Scene 表現・VRM 表示
  - アバター設定データ（public/avatars.json）
  - Scene 構成型定義・Stage ページの制御

- **技術的判断:**
  - 視覚効果は Scene 側の設定で集約し、描画系コンポーネントに反映する構成とした。

- **移行/破壊的変更:**
  - None

## 3. 検証（Proof）

- **カバレッジ:**
  - 視覚効果の適用とカメラ追従対象の切り替えが期待通り反映されること。

### Manual Tests

- [ ] 未実施

### Automated Tests

- [ ] 未実施
- [ ] 新しいテスト未追加

### Screenshots/Media

- 要追加（UI/Visual 変更あり）

## 4. リスク

- 視覚効果追加による描画負荷増加
- アバター設定の変更による既存データ互換性

## 5. セルフチェック

- [x] タイトルが明確で簡潔である。
- [x] 説明が完成しており、上記の構造に従っている。
- [x] コードが lint/format 済みである。
- [x] テストがローカルで通る。
- [x] 余計なファイル（デバッグログ、テンポラリファイルなど）が含まれていない。
