### PR TITLE
chore(vtube-stage): Electron 43 へ更新し CI を Node 22 に引き上げ

### DIFF
--- a/.github/workflows/vtube-stage-ci.yml
+++ b/.github/workflows/vtube-stage-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
           cache-dependency-path: packages/vtube-stage/package-lock.json
 

--- a/packages/vtube-stage/package-lock.json
+++ b/packages/vtube-stage/package-lock.json
@@ -23,7 +23,7 @@
         "class-validator": "^0.14.4",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
-        "electron": "^40.10.6",
+        "electron": "^43.1.1",
         "express": "^5.2.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -4815,10 +4815,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
-      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
-      "hasInstallScript": true,
+      "version": "43.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
+      "integrity": "sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -4826,7 +4825,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/packages/vtube-stage/package.json
+++ b/packages/vtube-stage/package.json
@@ -64,7 +64,7 @@
     "class-validator": "^0.14.4",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
-    "electron": "^40.10.6",
+    "electron": "^43.1.1",
     "express": "^5.2.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
依存更新 PR 群（G1〜G6）の 3 番目です（#35, #36 の続き）。

## 変更内容
- electron ^40.10.6 → ^43.1.1（41〜43 の破壊的変更は本プロジェクト不使用領域のみ。electron/ 配下は app / BrowserWindow / ipcMain / contextBridge 等の基本 API のみ使用）
- CI の Node を 20.x → 22.x（electron@43 の engines が Node >=22.12 を要求するため）
- electron-builder は ^26.15.3 のまま

## 検証
- `npm install` / `npm run lint` / `npm run build` ✅

## ⚠️ 既存問題の発見: build:win（NSIS パッケージング）が壊れています
`npm run build:win` は electron-builder の `⨯ Package "electron" is only allowed in "devDependencies"` で失敗しますが、**これは本 PR 起因ではありません**。electron 40 のままの base ブランチでも同一エラーで再現することを worktree で確認済みです。

厄介なのは単純な修正ができない点です:
- electron を devDependencies に移せば NSIS ビルドは通る（worktree で確認済み）
- しかし `bin/vtube-stage.cjs` が実行時に `require('electron')` するため、GitHub npm registry への CLI 配布では electron が runtime dependency である必要がある

つまり「npm CLI 配布」と「electron-builder での NSIS 配布」の設計が両立していません。対応方針（例: bin 配布をやめる / optionalDependencies 化 / electron-builder 設定での回避）は別課題としてご判断ください。

## 手動確認をお願いしたい点
- [ ] Electron 43 でのアプリ起動スモーク（`npm run dev` でウィンドウ表示・VRM 描画・MCP サーバー起動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)