### PR TITLE
fix(vtuber-behavior-engine): chromadb 1.5.9 で main.py が起動時クラッシュする問題を修正

### DIFF
--- a/packages/vtuber-behavior-engine/src/vtuber_behavior_engine/services/memory/chroma_memory_service.py
+++ b/packages/vtuber-behavior-engine/src/vtuber_behavior_engine/services/memory/chroma_memory_service.py
@@ -7,7 +7,6 @@ from typing import Callable
 
 import chromadb
 from chromadb import QueryResult
-from chromadb.utils import embedding_functions
 from google.adk.events import Event
 from google.adk.memory import BaseMemoryService
 from google.adk.memory.base_memory_service import SearchMemoryResponse
@@ -33,7 +32,12 @@ class ChromaMemoryService(BaseMemoryService):
         self._client = chromadb.PersistentClient(
             str(self._db_path),
         )
-        embedding_functions.GoogleGenerativeAiEmbeddingFunction(api_key_env_var="GOOGLE_API_KEY")
+        # NOTE: 旧実装はここで GoogleGenerativeAiEmbeddingFunction を生成していたが、
+        # コレクションに渡しておらず埋め込みには一切使われていなかった（実際の埋め込みは
+        # chromadb デフォルトの ONNX MiniLM）。chromadb 1.5.9 では旧 google-generativeai
+        # SDK との非互換でこの生成自体がクラッシュするため、死んでいた生成を削除した。
+        # Gemini 埋め込み（GoogleGenaiEmbeddingFunction）への移行は既存コレクションの
+        # 再埋め込みが必要なため別課題。
         self._collection = self._client.get_or_create_collection(
             name="vtuber_sessions",
         )

--- a/packages/vtuber-behavior-engine/src/vtuber_behavior_engine/services/memory/chroma_memory_service.py
+++ b/packages/vtuber-behavior-engine/src/vtuber_behavior_engine/services/memory/chroma_memory_service.py
@@ -32,7 +32,9 @@ class ChromaMemoryService(BaseMemoryService):
         self._client = chromadb.PersistentClient(
             str(self._db_path),
         )
-        # NOTE: 現在はデフォルトの ONNX MiniLM 埋め込みを使用しています。\n        # Gemini 埋め込み（GoogleGenaiEmbeddingFunction）への移行は、\n        # 既存コレクションの再埋め込み（マイグレーション）が必要となるため、別課題として扱います。
+        # NOTE: 現在はデフォルトの ONNX MiniLM 埋め込みを使用しています。
+        # Gemini 埋め込み（GoogleGenaiEmbeddingFunction）への移行は、
+        # 既存コレクションの再埋め込み（マイグレーション）が必要となるため、別課題として扱います。
         self._collection = self._client.get_or_create_collection(
             name="vtuber_sessions",
         )

--- a/packages/vtuber-behavior-engine/src/vtuber_behavior_engine/services/memory/chroma_memory_service.py
+++ b/packages/vtuber-behavior-engine/src/vtuber_behavior_engine/services/memory/chroma_memory_service.py
@@ -32,12 +32,7 @@ class ChromaMemoryService(BaseMemoryService):
         self._client = chromadb.PersistentClient(
             str(self._db_path),
         )
-        # NOTE: 旧実装はここで GoogleGenerativeAiEmbeddingFunction を生成していたが、
-        # コレクションに渡しておらず埋め込みには一切使われていなかった（実際の埋め込みは
-        # chromadb デフォルトの ONNX MiniLM）。chromadb 1.5.9 では旧 google-generativeai
-        # SDK との非互換でこの生成自体がクラッシュするため、死んでいた生成を削除した。
-        # Gemini 埋め込み（GoogleGenaiEmbeddingFunction）への移行は既存コレクションの
-        # 再埋め込みが必要なため別課題。
+        # NOTE: 現在はデフォルトの ONNX MiniLM 埋め込みを使用しています。\n        # Gemini 埋め込み（GoogleGenaiEmbeddingFunction）への移行は、\n        # 既存コレクションの再埋め込み（マイグレーション）が必要となるため、別課題として扱います。
         self._collection = self._client.get_or_create_collection(
             name="vtuber_sessions",
         )


### PR DESCRIPTION
## 症状
`main.py` 実行時に `ValueError: ClientOptions does not accept an option 'headers'` で起動不能（logs/app_20260719.log）。

## 原因
- #34 で chromadb が 1.4.0 → 1.5.9 に更新され、`GoogleGenerativeAiEmbeddingFunction` がテレメトリヘッダーを `client_options` 経由で旧 SDK（google-generativeai、EOL）に渡すようになった（chromadb PR #6990）。旧 SDK + google-api-core はこれを受け付けず必ずクラッシュする。最新の chromadb 1.5.9 でも未修正
- `adk web` 経由では `ChromaMemoryService` を通らないため表面化しなかった（main.py の前回実行は 2026-01-17）

## 修正
`ChromaMemoryService.__init__` の該当 EF 生成を削除（1 行 + import）。この EF は**生成後どこにも渡されておらず**、コレクションは従来から chromadb デフォルト埋め込み（ローカル ONNX MiniLM）で動作していたため、削除による挙動変化はありません。

## 検証
- black / flake8 / mypy(strict) / pytest ✅（17 passed, 1 skipped）
- E2E: `ChromaMemoryService` の生成（クラッシュ解消）→ セッション追加 → 検索ヒットまでラウンドトリップ確認 ✅

## 別課題（必要ならご相談ください）
本来の意図が Gemini 埋め込みの使用だった場合、chromadb 1.5.9 同梱の新 SDK ベース `GoogleGenaiEmbeddingFunction` への切り替えが可能ですが、既存コレクションの再埋め込み（マイグレーション）が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)