### PR TITLE
fix(vtube-stage): アバター設定パラメータを必須化

### DIFF
--- a/packages/vtube-stage/src/components/VRMAvatar.tsx
+++ b/packages/vtube-stage/src/components/VRMAvatar.tsx
@@ -25,17 +25,17 @@ export interface VRMAvatarProps {
   onLoad?: (vrm: VRM) => void;
   onTTSComplete?: (speakId: string) => void;
   onAnimationEnd?: (animationName: string) => void;
-  height?: number;
-  voiceVoxSpeaker?: string;
+  height: number;
+  voiceVoxSpeaker: string;
   name?: string;
-  lookAtConfig?: {
+  lookAtConfig: {
     yawLimitDeg: number;
     pitchLimitDeg: number;
     headWeight: number;
     neckWeight: number;
-    disableLookAtAnimations?: string[];
+    disableLookAtAnimations: string[];
   };
-  blinkConfig?: {
+  blinkConfig: {
     disabledEmotions: string[];
   };
   autoReturnToIdleTimeout?: number;
@@ -218,7 +218,7 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
   const playTTS = useCallback(
     async (text: string, onPlay?: () => void, style?: string) => {
       console.log('[TTS] playTTS called with text:', text);
-      await playVoice(text, onPlay, style, voiceVoxSpeaker); // onPlayを渡す, speakerPass
+      await playVoice(text, voiceVoxSpeaker, onPlay, style);
     },
     [voiceVoxSpeaker]
   );
@@ -249,7 +249,7 @@ export const VRMAvatar: React.FC<VRMAvatarProps> = ({
       <primitive object={lookAtTargetRef.current} />
 
       {/* Add SpeechBubble as a child, positioned relative to the avatar */}
-      {bubbleText && <SpeechBubble message={bubbleText} position={[0, height || 1.8, 0]} />}
+      {bubbleText && <SpeechBubble message={bubbleText} position={[0, height, 0]} />}
     </primitive>
   ) : null;
 };

--- a/packages/vtube-stage/src/constants/avatar_config.ts
+++ b/packages/vtube-stage/src/constants/avatar_config.ts
@@ -1,8 +1,0 @@
-export const DEFAULT_AVATAR_CONFIG = {
-  blink: {
-    disabledEmotions: ['happy', 'sleepy', 'wink'],
-  },
-  lookAt: {
-    disabledAnimations: ['agree', 'no', 'sleep'],
-  },
-};

--- a/packages/vtube-stage/src/hooks/useAvatarBlink.ts
+++ b/packages/vtube-stage/src/hooks/useAvatarBlink.ts
@@ -1,8 +1,7 @@
 import { useCallback, useRef } from 'react';
 import { VRM } from '@pixiv/three-vrm';
-import { DEFAULT_AVATAR_CONFIG } from '../constants/avatar_config';
 
-export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string, config?: { disabledEmotions: string[] }) => {
+export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string, config: { disabledEmotions: string[] }) => {
   const blinkTimerRef = useRef<number>(Math.random() * 2 + 1); // 瞬きタイマー
   const isBlinkingRef = useRef<boolean>(false);
   const blinkProgressRef = useRef<number>(0);
@@ -11,7 +10,7 @@ export const useAvatarBlink = (vrm: VRM | null, currentEmotion: string, config?:
     (delta: number) => {
       if (!vrm || !vrm.expressionManager) return;
 
-      const disabledEmotions = config?.disabledEmotions ?? DEFAULT_AVATAR_CONFIG.blink.disabledEmotions;
+      const disabledEmotions = config.disabledEmotions;
       if (disabledEmotions.includes(currentEmotion)) {
         // happyなどのときは瞬きしない（笑顔で目が細くなっているため干渉を防ぐ）
         vrm.expressionManager.setValue('blink', 0);

--- a/packages/vtube-stage/src/hooks/useAvatarLookAt.ts
+++ b/packages/vtube-stage/src/hooks/useAvatarLookAt.ts
@@ -2,18 +2,17 @@ import { useCallback, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { VRM } from '@pixiv/three-vrm';
 import { RootState } from '@react-three/fiber';
-import { DEFAULT_AVATAR_CONFIG } from '../constants/avatar_config';
 
 export const useAvatarLookAt = (
   vrm: VRM | null,
   isLoaded: boolean,
   currentAnimationName: string | null,
-  config?: {
+  config: {
     yawLimitDeg: number;
     pitchLimitDeg: number;
     headWeight: number;
     neckWeight: number;
-    disableLookAtAnimations?: string[];
+    disableLookAtAnimations: string[];
   }
 ) => {
   const lookAtTargetRef = useRef<THREE.Object3D>(new THREE.Object3D());
@@ -39,7 +38,7 @@ export const useAvatarLookAt = (
       const localHeadPos = vrm.scene.worldToLocal(headWorldPos);
 
       // 特定のアニメーションの最中はLookAtを無効化し、正面を見るようにする
-      const disabledAnimations = config?.disableLookAtAnimations ?? DEFAULT_AVATAR_CONFIG.lookAt.disabledAnimations;
+      const disabledAnimations = config.disableLookAtAnimations;
       if (currentAnimationName && disabledAnimations.includes(currentAnimationName)) {
         // ローカル座標系で正面(Z+)にターゲットを置く
         const centerDir = new THREE.Vector3(0, 0, 1.0);
@@ -65,16 +64,16 @@ export const useAvatarLookAt = (
       let pitch = Math.atan2(targetDir.y, xzLen);
 
       // 角度制限 (ラジアン)
-      const yawLimit = (config?.yawLimitDeg ?? 50) * (Math.PI / 180);
-      const pitchLimit = (config?.pitchLimitDeg ?? 30) * (Math.PI / 180);
+      const yawLimit = config.yawLimitDeg * (Math.PI / 180);
+      const pitchLimit = config.pitchLimitDeg * (Math.PI / 180);
 
       yaw = THREE.MathUtils.clamp(yaw, -yawLimit, yawLimit);
       pitch = THREE.MathUtils.clamp(pitch, -pitchLimit, pitchLimit);
 
       // --- Head & Neck Rotation Application ---
       // 回転をHeadとNeckに分配する比率 (例: Head 50%, Neck 50%)
-      const headWt = config?.headWeight ?? 0.5;
-      const neckWt = config?.neckWeight ?? 0.5;
+      const headWt = config.headWeight;
+      const neckWt = config.neckWeight;
 
       // 目線 (VRM LookAt) 用のターゲット計算
       // 制限した角度から位置を再計算

--- a/packages/vtube-stage/src/hooks/useStageCommandHandler.ts
+++ b/packages/vtube-stage/src/hooks/useStageCommandHandler.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useStageConnection } from './useStageConnection';
 import { validateStageCommand } from '../utils/command_validator';
+import { validateAvatarConfigs } from '../utils/avatar_validator';
 import { AvatarState } from '../types/avatar_types';
 import { StageCommand } from '../types/command';
 import { StageState } from '../types/scene_types';
@@ -146,9 +147,11 @@ export function useStageCommandHandler() {
         return res.json();
       })
       .then(data => {
+        const validatedAvatars = validateAvatarConfigs(data);
+
         // Resolve asset paths
-        const newAvatars = data.map((avatar: AvatarState) => {
-          const newAvatar = { ...avatar };
+        const newAvatars = validatedAvatars.map((avatar): AvatarState => {
+          const newAvatar: AvatarState = { ...avatar, speechText: null };
           if (newAvatar.vrmUrl) {
             newAvatar.vrmUrl = toAssetPath(newAvatar.vrmUrl);
           }

--- a/packages/vtube-stage/src/services/tts_service.ts
+++ b/packages/vtube-stage/src/services/tts_service.ts
@@ -36,11 +36,9 @@ export function splitAndMergeSentences(input: string): string[] {
 
 import { VOICE_VOX_SPEAKERS } from '../constants/voice_vox_speakers';
 
-function getSpeakerId(voiceVoxSpeaker?: string, style?: string): number {
-  // デフォルト: ずんだもん ノーマル (3)
+function getSpeakerId(voiceVoxSpeaker: string, style?: string): number {
+  // 未知の話者名が指定された場合のフォールバック: ずんだもん ノーマル (3)
   const DEFAULT_ID = 3;
-
-  if (!voiceVoxSpeaker) return DEFAULT_ID;
 
   const speaker = VOICE_VOX_SPEAKERS.find(s => s.name === voiceVoxSpeaker);
   if (!speaker) return DEFAULT_ID;
@@ -57,9 +55,9 @@ function getSpeakerId(voiceVoxSpeaker?: string, style?: string): number {
 
 export async function playVoice(
   text: string,
+  voiceVoxSpeaker: string,
   onPlay?: () => void,
-  style?: string,
-  voiceVoxSpeaker?: string
+  style?: string
 ): Promise<void> {
   const speakerId = getSpeakerId(voiceVoxSpeaker, style);
 

--- a/packages/vtube-stage/src/types/avatar_types.ts
+++ b/packages/vtube-stage/src/types/avatar_types.ts
@@ -10,7 +10,7 @@ export interface SpeakMessage {
 export interface AvatarState {
   id: string;
   name?: string; // Display name
-  voiceVoxSpeaker?: string; // VoiceVox matching name
+  voiceVoxSpeaker: string; // VoiceVox matching name
   vrmUrl: string;
   animationUrls: { [key: string]: string };
   currentEmotion: string;
@@ -19,15 +19,15 @@ export interface AvatarState {
   position: [number, number, number];
   onTTSComplete?: (speakId: string) => void;
   onAnimationEnd?: (animationName: string) => void;
-  height?: number;
-  lookAtConfig?: {
+  height: number;
+  lookAtConfig: {
     yawLimitDeg: number;
     pitchLimitDeg: number;
     headWeight: number;
     neckWeight: number;
-    disableLookAtAnimations?: string[];
+    disableLookAtAnimations: string[];
   };
-  blinkConfig?: {
+  blinkConfig: {
     disabledEmotions: string[];
   };
   autoReturnToIdleTimeout?: number;

--- a/packages/vtube-stage/src/utils/avatar_validator.ts
+++ b/packages/vtube-stage/src/utils/avatar_validator.ts
@@ -45,7 +45,8 @@ export function validateAvatarConfigs(data: unknown): ValidatedAvatarConfig[] {
     if (result.success) {
       validAvatars.push(result.data);
     } else {
-      const id = typeof entry === 'object' && entry !== null && 'id' in entry ? (entry as { id: unknown }).id : '(unknown)';
+      const id =
+        typeof entry === 'object' && entry !== null && 'id' in entry ? (entry as { id: unknown }).id : '(unknown)';
       console.error(`Invalid avatar config (id=${String(id)}) in avatars.json, skipping:`, result.error.format());
     }
   }

--- a/packages/vtube-stage/src/utils/avatar_validator.ts
+++ b/packages/vtube-stage/src/utils/avatar_validator.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+// avatars.json の各エントリが満たすべき形状。
+// VRM ごとに値が変わる項目（height, voiceVoxSpeaker, lookAtConfig, blinkConfig）は
+// 欠落・不正値のまま読み込まれないよう厳密にチェックする。
+const AvatarConfigSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().optional(),
+  voiceVoxSpeaker: z.string().min(1),
+  vrmUrl: z.string().min(1),
+  animationUrls: z.record(z.string(), z.string()),
+  currentEmotion: z.string(),
+  currentAnimationName: z.string().nullable(),
+  position: z.tuple([z.number(), z.number(), z.number()]),
+  height: z.number().finite().positive(),
+  lookAtConfig: z.object({
+    yawLimitDeg: z.number(),
+    pitchLimitDeg: z.number(),
+    headWeight: z.number(),
+    neckWeight: z.number(),
+    disableLookAtAnimations: z.array(z.string()),
+  }),
+  blinkConfig: z.object({
+    disabledEmotions: z.array(z.string()),
+  }),
+  autoReturnToIdleTimeout: z.number().optional(),
+});
+
+export type ValidatedAvatarConfig = z.infer<typeof AvatarConfigSchema>;
+
+/**
+ * avatars.json からロードした配列を検証し、不正なエントリを除外する。
+ * @param data avatars.json をパースした結果（unknown 前提）
+ * @returns 検証を通過したアバター設定の配列
+ */
+export function validateAvatarConfigs(data: unknown): ValidatedAvatarConfig[] {
+  if (!Array.isArray(data)) {
+    console.error('avatars.json must be an array of avatar configs');
+    return [];
+  }
+
+  const validAvatars: ValidatedAvatarConfig[] = [];
+  for (const entry of data) {
+    const result = AvatarConfigSchema.safeParse(entry);
+    if (result.success) {
+      validAvatars.push(result.data);
+    } else {
+      const id = typeof entry === 'object' && entry !== null && 'id' in entry ? (entry as { id: unknown }).id : '(unknown)';
+      console.error(`Invalid avatar config (id=${String(id)}) in avatars.json, skipping:`, result.error.format());
+    }
+  }
+  return validAvatars;
+}


### PR DESCRIPTION
## Summary
- VRM モデルごとに異なる挙動・設定値（瞬き無効化する感情、LookAt を無効化するアニメーション、身長、VOICEVOX 話者）について、暗黙のデフォルト値へのフォールバックを廃止し、`avatars.json` での明示的な設定を必須化
- `DEFAULT_AVATAR_CONFIG`（`constants/avatar_config.ts`）を削除
- `AvatarState` / `VRMAvatarProps` の `lookAtConfig`, `blinkConfig`, `height`, `voiceVoxSpeaker` を必須プロパティに変更
- `playVoice` の引数順を `(text, voiceVoxSpeaker, onPlay?, style?)` に変更（TS の制約上、必須引数を先頭側に配置）

## Test plan
- [x] `npx tsc --noEmit -p packages/vtube-stage/tsconfig.json` がエラーなしで完了することを確認
- [x] `public/avatars.json` の既存2アバターが引き続き正しく表示・音声再生されることを実機で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)